### PR TITLE
Made edit icon visible

### DIFF
--- a/public/css/theme.css
+++ b/public/css/theme.css
@@ -58,7 +58,6 @@ label {
   cursor: pointer;
 }
 
-.fa-solid,
 .fa-pen-to-square {
   color: #fff;
 }

--- a/public/css/theme.css
+++ b/public/css/theme.css
@@ -58,6 +58,11 @@ label {
   cursor: pointer;
 }
 
+.fa-solid,
+.fa-pen-to-square {
+  color: #fff;
+}
+
 /* body {
   font: 300 20px / 1.5 "Anybody", "sans-serif", cursive;
   font-style: italic;


### PR DESCRIPTION
Made slight change and removed fa-solid from theme.css as it interfered with yellow star important color. Still makes edit icon show up across colors